### PR TITLE
feat(markdown): render D2 diagrams in Markdown preview with theme support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@ This file provides guidance to coding agents working in this repository.
 
 This is a JetBrains IntelliJ Platform plugin that provides D2 (Declarative Diagramming) language support for IntelliJ-based IDEs. The plugin offers syntax highlighting, live preview, autocomplete, and export capabilities for `.d2` files.
 
-**Plugin ID:** `com.troodon.d2`  
-**Current Version:** 1.0.7  
-**Minimum IDE Build:** 243 (IntelliJ IDEA 2024.3+)  
-**Target JVM:** 21  
+**Plugin ID:** `com.troodon.d2`
+**Current Version:** 1.0.12
+**Minimum IDE Build:** 243 (IntelliJ IDEA 2024.3+)
+**Target JVM:** 21
 **Primary Language:** Kotlin
 
 ## Development Commands
@@ -32,6 +32,17 @@ This is a JetBrains IntelliJ Platform plugin that provides D2 (Declarative Diagr
 
 # Clean build artifacts
 ./gradlew clean
+
+# Launch sandboxed IDE with plugin loaded
+./gradlew runIde
+
+# Version management (via Makefile)
+make bump-patch   # bump patch version
+make bump-minor   # bump minor version
+make bump-major   # bump major version
+make build        # alias for ./gradlew buildPlugin
+make test         # alias for ./gradlew test
+make run          # alias for ./gradlew runIde
 ```
 
 ## Architecture Overview
@@ -56,6 +67,7 @@ This is a JetBrains IntelliJ Platform plugin that provides D2 (Declarative Diagr
   - `D2IdentifierCompletionProvider`: Suggests defined objects/connections
   - `D2NodePropertyCompletionProvider`: Suggests node properties (shape, icon, style, label)
   - `D2ShapeCompletionProvider`: Suggests shape values (rectangle, circle, etc.)
+  - `D2StylePropertyCompletionProvider`: Suggests style properties inside `style {}` blocks (opacity, fill, stroke, etc.)
 - `D2TypedHandler`: Auto-triggers completion as user types
 - `D2PairedBraceMatcher`: Brace matching for `{}` pairs
 - `D2Commenter`: Line and block comment support
@@ -78,6 +90,9 @@ This is a JetBrains IntelliJ Platform plugin that provides D2 (Declarative Diagr
   - `d2CliPath`: Path to D2 executable (auto-detects if empty)
   - `d2Arguments`: Additional CLI args (default: `--animate-interval=1000`)
   - `debounceDelay`: Auto-refresh delay in ms (default: 1000)
+  - `previewBackground`: Background mode (IDE Theme / Transparent / Light / Dark / Custom color)
+  - `useWsl`: Toggle WSL2 support (Windows Subsystem for Linux)
+  - `wslDistribution`: WSL distribution name to use
 - `D2SettingsConfigurable`: Settings UI panel
 - `D2CliValidator`: Validates D2 installation and finds executable
 - `D2LanguageCodeStyleSettingsProvider`: Code style configuration

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Comprehensive D2 language support for IntelliJ-based IDEs. Create beautiful diag
 - 💡 **Autocomplete** - Smart completion for identifiers, node properties, and shape values
 - 🎯 **File Type Icon** - Custom icon for `.d2` files in project tree
 - ⚙️ **Configurable D2 CLI** - Set the D2 executable path and additional CLI arguments (e.g., `--animate-interval=1000`)
+- 📝 **Markdown Preview** - Renders ` ```d2 ` fenced code blocks as inline SVG diagrams inside the IDE's Markdown preview
 
 <div>
   <img src="docs/assets/demo.gif" alt="D2" width="920" />
@@ -52,14 +53,18 @@ For other installation methods, visit [d2lang.com](https://d2lang.com/tour/insta
 
 ## 💡 About D2
 
-D2 is a modern diagram scripting language that turns text into diagrams. It's designed to be easy to learn, powerful, and flexible.
+D2 is a modern diagram scripting language that turns text into diagrams. It's designed to be easy to learn, powerful, and flexible. Learn more at [d2lang.com](https://d2lang.com).
 
 **Example D2 code:**
-```d2
+```
 x -> y: hello world
 ```
 
-Learn more at [d2lang.com](https://d2lang.com).
+D2 diagrams also render inline inside Markdown files — just use a fenced ` ```d2 ` block:
+
+```d2
+x -> y: hello world
+```
 
 ## 🤝 Contributing
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,9 @@ dependencies {
         testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
 
 
-        // Add plugin dependencies for compilation here, example:
+        // Markdown plugin for Markdown preview extension support
+        bundledPlugin("org.intellij.plugins.markdown")
+        // Add other plugin dependencies for compilation here, example:
         // bundledPlugin("com.intellij.java")
     }
     testImplementation(kotlin("test"))

--- a/src/main/kotlin/com/troodon/d2/markdown/D2MarkdownPreviewExtension.kt
+++ b/src/main/kotlin/com/troodon/d2/markdown/D2MarkdownPreviewExtension.kt
@@ -3,6 +3,7 @@ package com.troodon.d2.markdown
 import com.google.gson.Gson
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.ui.JBColor
 import com.troodon.d2.settings.D2SettingsState
 import org.intellij.plugins.markdown.extensions.MarkdownBrowserPreviewExtension
 import org.intellij.plugins.markdown.ui.preview.BrowserPipe
@@ -59,10 +60,15 @@ private class D2BrowserExtension(
                 val resultJson = try {
                     val project = panel.project ?: return@executeOnPooledThread
                     val settings = D2SettingsState.getInstance(project)
+                    // If the IDE is in dark mode and the user has not already set a --theme flag, inject D2's dark theme.
+                    val themeArgs = if (!JBColor.isBright() && !settings.d2Arguments.contains("--theme")) "--theme 200" else ""
+                    val effectiveArgs = listOf(themeArgs, settings.d2Arguments)
+                        .filter { it.isNotBlank() }
+                        .joinToString(" ")
                     val svg = D2Runner.renderToSvg(
                         request.source,
                         settings.getEffectiveD2Path(),
-                        settings.d2Arguments,
+                        effectiveArgs,
                         settings.useWsl,
                         settings.wslDistribution
                     )

--- a/src/main/kotlin/com/troodon/d2/markdown/D2MarkdownPreviewExtension.kt
+++ b/src/main/kotlin/com/troodon/d2/markdown/D2MarkdownPreviewExtension.kt
@@ -1,0 +1,120 @@
+package com.troodon.d2.markdown
+
+import com.google.gson.Gson
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.troodon.d2.settings.D2SettingsState
+import org.intellij.plugins.markdown.extensions.MarkdownBrowserPreviewExtension
+import org.intellij.plugins.markdown.ui.preview.BrowserPipe
+import org.intellij.plugins.markdown.ui.preview.MarkdownHtmlPanel
+import org.intellij.plugins.markdown.ui.preview.ResourceProvider
+
+/**
+ * Registers as a Markdown browser preview extension provider.
+ *
+ * When active it injects [d2-markdown-render.js] into the JCEF Markdown
+ * preview. The script finds every <pre><code class="language-d2"> element,
+ * sends the D2 source to Kotlin via BrowserPipe, and replaces the block with
+ * the returned SVG wrapped in a Shadow DOM.
+ *
+ * Activated only when the Markdown plugin is present (optional dependency).
+ */
+class D2MarkdownPreviewExtension : MarkdownBrowserPreviewExtension.Provider {
+    override fun createBrowserExtension(panel: MarkdownHtmlPanel): MarkdownBrowserPreviewExtension =
+        D2BrowserExtension(panel)
+}
+
+// ---------------------------------------------------------------------------
+
+private data class RenderRequest(val id: String, val source: String)
+private data class RenderResult(val id: String, val svg: String? = null, val error: String? = null)
+
+private class D2BrowserExtension(
+    private val panel: MarkdownHtmlPanel
+) : MarkdownBrowserPreviewExtension {
+
+    private val log = Logger.getInstance(D2BrowserExtension::class.java)
+    private val gson = Gson()
+
+    @Volatile
+    private var disposed = false
+
+    /**
+     * BrowserPipe.Handler is not a functional interface — must use object expression.
+     * Called when JS posts 'd2/render' with payload {"id":"<req>","source":"<d2>"}.
+     */
+    private val renderHandler = object : BrowserPipe.Handler {
+        override fun processMessageReceived(message: String): Boolean {
+            val request = try {
+                gson.fromJson(message, RenderRequest::class.java)
+            } catch (e: Exception) {
+                log.warn("D2: failed to parse render request: $message", e)
+                return false
+            }
+
+            // D2 CLI is blocking — run on a pooled thread
+            ApplicationManager.getApplication().executeOnPooledThread {
+                if (disposed) return@executeOnPooledThread
+
+                val resultJson = try {
+                    val project = panel.project ?: return@executeOnPooledThread
+                    val settings = D2SettingsState.getInstance(project)
+                    val svg = D2Runner.renderToSvg(
+                        request.source,
+                        settings.getEffectiveD2Path(),
+                        settings.d2Arguments,
+                        settings.useWsl,
+                        settings.wslDistribution
+                    )
+                    gson.toJson(RenderResult(id = request.id, svg = svg))
+                } catch (e: Exception) {
+                    log.warn("D2: render failed for request ${request.id}", e)
+                    gson.toJson(RenderResult(id = request.id, error = buildErrorMessage(e)))
+                }
+
+                if (!disposed) {
+                    panel.browserPipe?.send("d2/result", resultJson)
+                }
+            }
+            return true
+        }
+    }
+
+    init {
+        panel.browserPipe?.subscribe("d2/render", renderHandler)
+    }
+
+    override val scripts: List<String> = listOf("d2-markdown-render.js")
+    override val styles: List<String> = emptyList()
+
+    override val resourceProvider: ResourceProvider = object : ResourceProvider {
+        override fun canProvide(resourceName: String): Boolean =
+            resourceName == "d2-markdown-render.js"
+
+        override fun loadResource(resourceName: String): ResourceProvider.Resource? =
+            ResourceProvider.loadInternalResource(
+                D2BrowserExtension::class.java,
+                "/d2-markdown-render.js",
+                "text/javascript"
+            )
+    }
+
+    override fun dispose() {
+        disposed = true
+        panel.browserPipe?.removeSubscription("d2/render", renderHandler)
+    }
+
+    override fun compareTo(other: MarkdownBrowserPreviewExtension): Int = 0
+
+    private fun buildErrorMessage(e: Exception): String {
+        val msg = e.message ?: "Unknown error"
+        return if (msg.contains("No such file", ignoreCase = true) ||
+            msg.contains("not found", ignoreCase = true) ||
+            msg.contains("cannot find", ignoreCase = true)
+        ) {
+            "D2 not found. Install D2 and set the path in Settings \u203A Tools \u203A D2 Diagram."
+        } else {
+            msg
+        }
+    }
+}

--- a/src/main/kotlin/com/troodon/d2/markdown/D2Runner.kt
+++ b/src/main/kotlin/com/troodon/d2/markdown/D2Runner.kt
@@ -59,15 +59,20 @@ object D2Runner {
         stdoutThread.start()
         stderrThread.start()
 
-        writerThread.join(TIMEOUT_SECONDS * 1000)
-        stdoutThread.join(TIMEOUT_SECONDS * 1000)
-        stderrThread.join(TIMEOUT_SECONDS * 1000)
-
+        // Wait on the process first so the total timeout is TIMEOUT_SECONDS, not
+        // TIMEOUT_SECONDS * (number of threads). Once the process exits its streams
+        // reach EOF and the reader/writer threads finish almost immediately.
         val completed = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         if (!completed) {
             process.destroyForcibly()
             throw RuntimeException("D2 timed out after ${TIMEOUT_SECONDS}s")
         }
+
+        // Process has exited — a short safety timeout is enough.
+        val safetyMs = 2_000L
+        writerThread.join(safetyMs)
+        stdoutThread.join(safetyMs)
+        stderrThread.join(safetyMs)
 
         val exitCode = process.exitValue()
         if (stderr.isNotBlank()) LOG.debug("D2 stderr: $stderr")

--- a/src/main/kotlin/com/troodon/d2/markdown/D2Runner.kt
+++ b/src/main/kotlin/com/troodon/d2/markdown/D2Runner.kt
@@ -1,0 +1,78 @@
+package com.troodon.d2.markdown
+
+import com.intellij.openapi.diagnostic.Logger
+import com.troodon.d2.util.D2CommandBuilder
+import java.util.concurrent.TimeUnit
+
+object D2Runner {
+    private val LOG = Logger.getInstance(D2Runner::class.java)
+    private const val TIMEOUT_SECONDS = 10L
+
+    /**
+     * Overridable for testing. Accepts a command list and stdin string,
+     * returns (exitCode, combinedOutput).
+     */
+    internal var processRunner: (command: List<String>, stdin: String) -> Pair<Int, String> =
+        ::defaultRun
+
+    /**
+     * Renders [source] to SVG by piping it to the D2 CLI.
+     * Uses stdin → stdout (`d2 [args] - -`) so no temp file is needed.
+     *
+     * @throws RuntimeException if D2 is not found, times out, or exits non-zero.
+     */
+    fun renderToSvg(
+        source: String,
+        d2Path: String,
+        d2Arguments: String = "",
+        useWsl: Boolean = false,
+        wslDistro: String = ""
+    ): String {
+        val command = D2CommandBuilder.buildD2StdinStdoutCommand(d2Path, d2Arguments, useWsl, wslDistro)
+        val (exitCode, output) = processRunner(command, source)
+        if (exitCode != 0) {
+            throw RuntimeException("D2 exited with code $exitCode: ${output.take(500)}")
+        }
+        return output
+    }
+
+    private fun defaultRun(command: List<String>, input: String): Pair<Int, String> {
+        val process = ProcessBuilder(command).start()
+
+        // Write stdin on a separate thread to prevent deadlock when the process
+        // buffer fills up before we start reading stdout.
+        val writerThread = Thread {
+            try {
+                process.outputStream.bufferedWriter().use { it.write(input) }
+            } catch (_: Exception) {
+                // Process may have terminated early (e.g. parse error); ignore.
+            }
+        }
+        writerThread.start()
+
+        // Read stdout (SVG) and stderr separately so CLI progress messages
+        // on stderr don't pollute the SVG output.
+        var stdout = ""
+        var stderr = ""
+        val stdoutThread = Thread { stdout = process.inputStream.bufferedReader().readText() }
+        val stderrThread = Thread { stderr = process.errorStream.bufferedReader().readText() }
+        stdoutThread.start()
+        stderrThread.start()
+
+        writerThread.join(TIMEOUT_SECONDS * 1000)
+        stdoutThread.join(TIMEOUT_SECONDS * 1000)
+        stderrThread.join(TIMEOUT_SECONDS * 1000)
+
+        val completed = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!completed) {
+            process.destroyForcibly()
+            throw RuntimeException("D2 timed out after ${TIMEOUT_SECONDS}s")
+        }
+
+        val exitCode = process.exitValue()
+        if (stderr.isNotBlank()) LOG.debug("D2 stderr: $stderr")
+        // On error, include stderr in the message for diagnostics.
+        val output = if (exitCode != 0) stderr.ifBlank { stdout } else stdout
+        return Pair(exitCode, output)
+    }
+}

--- a/src/main/kotlin/com/troodon/d2/util/D2CommandBuilder.kt
+++ b/src/main/kotlin/com/troodon/d2/util/D2CommandBuilder.kt
@@ -81,6 +81,25 @@ object D2CommandBuilder {
     }
 
     /**
+     * Builds a D2 render command that reads from stdin and writes SVG to stdout.
+     * Used by the Markdown preview to avoid a temp output file.
+     */
+    fun buildD2StdinStdoutCommand(
+        d2Path: String,
+        d2Arguments: String,
+        useWsl: Boolean,
+        wslDistro: String = ""
+    ): List<String> {
+        val args = mutableListOf<String>()
+        if (d2Arguments.isNotBlank()) {
+            args.addAll(d2Arguments.split(Regex("\\s+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)")))
+        }
+        args.add("-") // stdin
+        args.add("-") // stdout (SVG)
+        return buildCommand(d2Path, args, useWsl, wslDistro)
+    }
+
+    /**
      * Builds a D2 version check command.
      */
     fun buildD2VersionCommand(

--- a/src/main/kotlin/com/troodon/d2/util/D2CommandBuilder.kt
+++ b/src/main/kotlin/com/troodon/d2/util/D2CommandBuilder.kt
@@ -2,6 +2,11 @@ package com.troodon.d2.util
 
 object D2CommandBuilder {
 
+    private val ARGUMENT_SPLIT_REGEX = Regex("\\s+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)")
+
+    private fun splitArguments(d2Arguments: String): List<String> =
+        if (d2Arguments.isBlank()) emptyList() else d2Arguments.split(ARGUMENT_SPLIT_REGEX)
+
     /**
      * Wraps a command list with `wsl.exe` when WSL mode is enabled.
      */
@@ -59,9 +64,7 @@ object D2CommandBuilder {
         wslDistro: String = ""
     ): List<String> {
         val args = mutableListOf<String>()
-        if (d2Arguments.isNotBlank()) {
-            args.addAll(d2Arguments.split(Regex("\\s+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)")))
-        }
+        args.addAll(splitArguments(d2Arguments))
         args.add("-")
         args.add(if (useWsl) convertToWslPath(outputFile) else outputFile)
         return buildCommand(d2Path, args, useWsl, wslDistro)
@@ -91,9 +94,7 @@ object D2CommandBuilder {
         wslDistro: String = ""
     ): List<String> {
         val args = mutableListOf<String>()
-        if (d2Arguments.isNotBlank()) {
-            args.addAll(d2Arguments.split(Regex("\\s+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)")))
-        }
+        args.addAll(splitArguments(d2Arguments))
         args.add("-") // stdin
         args.add("-") // stdout (SVG)
         return buildCommand(d2Path, args, useWsl, wslDistro)

--- a/src/main/resources/META-INF/markdown-preview.xml
+++ b/src/main/resources/META-INF/markdown-preview.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="org.intellij.markdown">
+        <browserPreviewExtensionProvider
+                implementation="com.troodon.d2.markdown.D2MarkdownPreviewExtension"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="markdown-preview.xml">org.intellij.plugins.markdown</depends>
 
     <!-- Extensions defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->

--- a/src/main/resources/d2-markdown-render.js
+++ b/src/main/resources/d2-markdown-render.js
@@ -1,0 +1,105 @@
+// Copyright 2025 D2 Diagram Plugin. Apache 2.0 license.
+// Injected into the IntelliJ Markdown JCEF preview.
+//
+// Timing notes (based on MarkdownJCEFHtmlPanel internals):
+//   1. This script executes as an inline <script> during HTML parsing.
+//   2. After the page fully loads, JcefBrowserPipeImpl sets up the message
+//      bridge and dispatches window.IdeReady — only then can we post messages.
+//   3. Markdown content is patched into the DOM via Incremental DOM.
+//      IncrementalDOM.notifications.afterPatchListeners is the correct hook
+//      for detecting content changes — the same mechanism used by MathJax and
+//      ScrollSync in the platform.  setTimeout / MutationObserver are not needed.
+(function () {
+  'use strict';
+
+  var ideReady = false;
+  var pendingRequests = {};
+  var requestCounter = 0;
+
+  // Receive rendered SVG (or error) back from Kotlin
+  window.__IntelliJTools.messagePipe.subscribe('d2/result', function (data) {
+    try {
+      var msg = JSON.parse(data);
+      var callback = pendingRequests[msg.id];
+      if (callback) {
+        delete pendingRequests[msg.id];
+        callback(msg.svg || null, msg.error || null);
+      }
+    } catch (e) {
+      console.error('[D2] Failed to parse result:', e);
+    }
+  });
+
+  // D2 CLI outputs SVGs with pixel-exact width/height matching the viewBox
+  // (e.g. viewBox="0 0 255 600" → width="255" height="600"), which renders too
+  // large next to Markdown text. Scale to 70% so diagrams are proportional.
+  // Tune this if diagrams look too big or too small.
+  var D2_SCALE = 0.7;
+
+  // Replaces width/height on the root <svg> with values scaled from the viewBox.
+  // e.g. viewBox="0 0 255 600" → <svg width="179" height="420"> (at 70%)
+  function setSvgNaturalSize(svg) {
+    var vb = svg.match(/viewBox="[\d.+-]+\s+[\d.+-]+\s+([\d.]+)\s+([\d.]+)"/);
+    if (!vb) return svg;
+    var w = Math.round(parseFloat(vb[1]) * D2_SCALE);
+    var h = Math.round(parseFloat(vb[2]) * D2_SCALE);
+    var s = svg.replace(/(<svg\b[^>]*?)\s+width="[^"]*"/, '$1');
+    s = s.replace(/(<svg\b[^>]*?)\s+height="[^"]*"/, '$1');
+    return s.replace(/(<svg\b[^>]*?)>/, '$1 width="' + w + '" height="' + h + '">');
+  }
+
+  function renderD2Blocks() {
+    if (!ideReady) return;
+    document.querySelectorAll('code.language-d2').forEach(function (el) {
+      if (el.dataset.d2Rendered) return;
+      el.dataset.d2Rendered = 'pending';
+
+      var pre = el.closest('pre') || el.parentElement;
+      var source = el.textContent;
+      var id = String(requestCounter++);
+
+      pendingRequests[id] = function (svg, error) {
+        if (error) {
+          el.dataset.d2Rendered = 'error';
+          var box = document.createElement('pre');
+          box.style.cssText =
+            'color:#c00;border:1px solid #c00;border-radius:4px;' +
+            'padding:8px;font-size:12px;white-space:pre-wrap;margin:4px 0;';
+          box.textContent = '\u26A0 D2: ' + error;
+          pre.replaceWith(box);
+        } else {
+          var host = document.createElement('div');
+          // Shadow DOM isolates D2's embedded <style> tags from the page.
+          var shadow = host.attachShadow({ mode: 'open' });
+          // Set intrinsic pixel dimensions from the SVG's viewBox so the browser
+          // renders it at its natural size rather than stretching to fill the column.
+          // max-width:100% still allows it to shrink on narrow screens.
+          shadow.innerHTML =
+            '<style>svg { max-width: 100%; height: auto; display: block; }</style>' +
+            setSvgNaturalSize(svg);
+          pre.replaceWith(host);
+        }
+      };
+
+      window.__IntelliJTools.messagePipe.post(
+        'd2/render',
+        JSON.stringify({ id: id, source: source })
+      );
+    });
+  }
+
+  // IdeReady fires once the Kotlin JCEF bridge is fully set up.
+  // Only after this event can we safely call messagePipe.post().
+  window.addEventListener('IdeReady', function () {
+    ideReady = true;
+    renderD2Blocks();
+  });
+
+  // IncrementalDOM.notifications.afterPatchListeners is the platform-correct
+  // hook for reacting to Markdown content changes.  Every time the preview
+  // re-renders (user edits, file switch, scroll), this callback fires.
+  // This is the same mechanism used by MathJax and ScrollSync.
+  IncrementalDOM.notifications.afterPatchListeners.push(function () {
+    renderD2Blocks();
+  });
+})();

--- a/src/main/resources/d2-markdown-render.js
+++ b/src/main/resources/d2-markdown-render.js
@@ -51,22 +51,52 @@
     });
   }
 
-  // D2 CLI outputs SVGs with pixel-exact width/height matching the viewBox
-  // (e.g. viewBox="0 0 255 600" → width="255" height="600"), which renders too
-  // large next to Markdown text. Scale to 70% so diagrams are proportional.
-  // Tune this if diagrams look too big or too small.
-  var D2_SCALE = 0.7;
+  // Proportional scale factor: 1.0 means the diagram renders at its natural
+  // pixel size at the current IDE Markdown font size. Increase to make diagrams
+  // larger relative to the text, decrease to make them smaller.
+  var D2_SCALE = 1.0;
 
-  // Replaces width/height on the root <svg> with values scaled from the viewBox.
-  // e.g. viewBox="0 0 255 600" → <svg width="179" height="420"> (at 70%)
-  function setSvgNaturalSize(svg) {
-    var vb = svg.match(/viewBox="[\d.+-]+\s+[\d.+-]+\s+([\d.]+)\s+([\d.]+)"/);
-    if (!vb) return svg;
-    var w = Math.round(parseFloat(vb[1]) * D2_SCALE);
-    var h = Math.round(parseFloat(vb[2]) * D2_SCALE);
+  // Read from document.body at IdeReady — this is where IntelliJ sets the
+  // Markdown preview font size. Font size changes cause a full page reload,
+  // so this value is always correct for the current session.
+  var refFontSize;
+
+  // Returns the viewBox width of the root <svg>, or null if not found.
+  function svgViewBoxWidth(svg) {
+    var vb = svg.match(/viewBox="[\d.+-]+\s+[\d.+-]+\s+([\d.]+)\s+[\d.]+"/);
+    return vb ? parseFloat(vb[1]) : null;
+  }
+
+  // Removes explicit width/height attributes from the root <svg> so CSS controls sizing.
+  function stripSvgDimensions(svg) {
     var s = svg.replace(/(<svg\b[^>]*?)\s+width="[^"]*"/, '$1');
-    s = s.replace(/(<svg\b[^>]*?)\s+height="[^"]*"/, '$1');
-    return s.replace(/(<svg\b[^>]*?)>/, '$1 width="' + w + '" height="' + h + '">');
+    return s.replace(/(<svg\b[^>]*?)\s+height="[^"]*"/, '$1');
+  }
+
+  function showD2Error(pre, error) {
+    var box = document.createElement('pre');
+    box.style.cssText =
+      'color:#c00;border:1px solid #c00;border-radius:4px;' +
+      'padding:8px;font-size:12px;white-space:pre-wrap;margin:4px 0;';
+    box.textContent = '\u26A0 D2: ' + error;
+    pre.replaceWith(box);
+  }
+
+  function showD2Svg(pre, svg) {
+    var host = document.createElement('div');
+    // Shadow DOM isolates D2's embedded <style> tags from the page.
+    var shadow = host.attachShadow({ mode: 'open' });
+    // Hoist @font-face rules to the light DOM so JCEF/Chromium resolves them.
+    hoistFontFaces(svg);
+    // Width in em causes the diagram to scale automatically with the IDE
+    // Markdown font size. height:auto preserves the aspect ratio.
+    // Falls back to max-width:100% if the SVG has no viewBox.
+    var vbWidth = svgViewBoxWidth(svg);
+    var svgCss = vbWidth
+      ? 'svg { width: ' + ((vbWidth * D2_SCALE) / refFontSize).toFixed(3) + 'em; height: auto; max-width: 100%; display: block; }'
+      : 'svg { max-width: 100%; height: auto; display: block; }';
+    shadow.innerHTML = '<style>' + svgCss + '</style>' + stripSvgDimensions(svg);
+    pre.replaceWith(host);
   }
 
   function renderD2Blocks() {
@@ -81,26 +111,9 @@
 
       pendingRequests[id] = function (svg, error) {
         if (error) {
-          el.dataset.d2Rendered = 'error';
-          var box = document.createElement('pre');
-          box.style.cssText =
-            'color:#c00;border:1px solid #c00;border-radius:4px;' +
-            'padding:8px;font-size:12px;white-space:pre-wrap;margin:4px 0;';
-          box.textContent = '\u26A0 D2: ' + error;
-          pre.replaceWith(box);
+          showD2Error(pre, error);
         } else {
-          var host = document.createElement('div');
-          // Shadow DOM isolates D2's embedded <style> tags from the page.
-          var shadow = host.attachShadow({ mode: 'open' });
-          // Hoist @font-face rules to the light DOM so JCEF/Chromium resolves them.
-          hoistFontFaces(svg);
-          // Set intrinsic pixel dimensions from the SVG's viewBox so the browser
-          // renders it at its natural size rather than stretching to fill the column.
-          // max-width:100% still allows it to shrink on narrow screens.
-          shadow.innerHTML =
-            '<style>svg { max-width: 100%; height: auto; display: block; }</style>' +
-            setSvgNaturalSize(svg);
-          pre.replaceWith(host);
+          showD2Svg(pre, svg);
         }
       };
 
@@ -115,6 +128,9 @@
   // Only after this event can we safely call messagePipe.post().
   window.addEventListener('IdeReady', function () {
     ideReady = true;
+    // Fallback of 16 is a last resort — if body has no computable font size
+    // something is already broken and diagrams will render at an arbitrary size.
+    refFontSize = parseFloat(getComputedStyle(document.body).fontSize) || 16;
     renderD2Blocks();
   });
 

--- a/src/main/resources/d2-markdown-render.js
+++ b/src/main/resources/d2-markdown-render.js
@@ -30,6 +30,27 @@
     }
   });
 
+  // JCEF/Chromium does not resolve @font-face declared inside a Shadow DOM
+  // style sheet. To fix this, extract @font-face rules from the SVG and inject
+  // them into document.head (light DOM) where the browser can load them.
+  // Base64 data URIs never contain '}', so the regex boundary is unambiguous.
+  // Font-family names are unique per D2 render (e.g. "d2-1447744005-font-bold"),
+  // so we deduplicate by name to avoid re-injecting on every re-render.
+  function hoistFontFaces(svg) {
+    var matches = svg.match(/@font-face\s*\{[^}]*\}/g) || [];
+    matches.forEach(function (rule) {
+      var nameMatch = rule.match(/font-family:\s*([^;"\n]+)/);
+      if (!nameMatch) return;
+      var key = nameMatch[1].trim().replace(/['"]/g, '');
+      if (!document.head.querySelector('style[data-d2-font="' + key + '"]')) {
+        var el = document.createElement('style');
+        el.setAttribute('data-d2-font', key);
+        el.textContent = rule;
+        document.head.appendChild(el);
+      }
+    });
+  }
+
   // D2 CLI outputs SVGs with pixel-exact width/height matching the viewBox
   // (e.g. viewBox="0 0 255 600" → width="255" height="600"), which renders too
   // large next to Markdown text. Scale to 70% so diagrams are proportional.
@@ -71,6 +92,8 @@
           var host = document.createElement('div');
           // Shadow DOM isolates D2's embedded <style> tags from the page.
           var shadow = host.attachShadow({ mode: 'open' });
+          // Hoist @font-face rules to the light DOM so JCEF/Chromium resolves them.
+          hoistFontFaces(svg);
           // Set intrinsic pixel dimensions from the SVG's viewBox so the browser
           // renders it at its natural size rather than stretching to fill the column.
           // max-width:100% still allows it to shrink on narrow screens.

--- a/src/main/resources/d2-markdown-render.js
+++ b/src/main/resources/d2-markdown-render.js
@@ -67,6 +67,30 @@
     return vb ? parseFloat(vb[1]) : null;
   }
 
+  // Removes the canvas background by finding the rect whose width and height match
+  // the viewBox dimensions (i.e. the full-canvas background rect D2 always emits).
+  // The rect is removed entirely rather than set to fill="none" because the SVG's
+  // embedded CSS class (fill-N7) would override a fill attribute, winning over it.
+  function stripSvgBackground(svg) {
+    var vb = svg.match(/viewBox="[\d.+-]+\s+[\d.+-]+\s+([\d.]+)\s+([\d.]+)"/);
+    if (!vb) return svg;
+    var vbW = parseFloat(vb[1]);
+    var vbH = parseFloat(vb[2]);
+    var replaced = false;
+    return svg.replace(/<rect\b([^>]*)\/>/g, function (match, attrs) {
+      if (replaced) return match;
+      var wMatch = attrs.match(/\bwidth="([^"]+)"/);
+      var hMatch = attrs.match(/\bheight="([^"]+)"/);
+      var fillMatch = attrs.match(/\bfill="([^"]+)"/);
+      if (!wMatch || !hMatch || !fillMatch) return match;
+      if (parseFloat(wMatch[1]) === vbW && parseFloat(hMatch[1]) === vbH && fillMatch[1] !== 'none') {
+        replaced = true;
+        return '';
+      }
+      return match;
+    });
+  }
+
   // Removes explicit width/height attributes from the root <svg> so CSS controls sizing.
   function stripSvgDimensions(svg) {
     var s = svg.replace(/(<svg\b[^>]*?)\s+width="[^"]*"/, '$1');
@@ -88,6 +112,8 @@
     var shadow = host.attachShadow({ mode: 'open' });
     // Hoist @font-face rules to the light DOM so JCEF/Chromium resolves them.
     hoistFontFaces(svg);
+
+    svg = stripSvgBackground(svg);
     // Width in em causes the diagram to scale automatically with the IDE
     // Markdown font size. height:auto preserves the aspect ratio.
     // Falls back to max-width:100% if the SVG has no viewBox.

--- a/src/test/kotlin/com/troodon/d2/markdown/D2RunnerTest.kt
+++ b/src/test/kotlin/com/troodon/d2/markdown/D2RunnerTest.kt
@@ -1,0 +1,109 @@
+package com.troodon.d2.markdown
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertContains
+
+class D2RunnerTest {
+
+    private val originalRunner = D2Runner.processRunner
+
+    @After
+    fun restoreRunner() {
+        D2Runner.processRunner = originalRunner
+    }
+
+    @Test
+    fun `renderToSvg returns stdout on success`() {
+        val fakeSvg = "<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100'/></svg>"
+        D2Runner.processRunner = { _, _ -> Pair(0, fakeSvg) }
+
+        val result = D2Runner.renderToSvg("x -> y", "/fake/d2")
+
+        assertEquals(fakeSvg, result)
+    }
+
+    @Test
+    fun `renderToSvg passes source as stdin`() {
+        val capturedStdin = mutableListOf<String>()
+        D2Runner.processRunner = { _, stdin ->
+            capturedStdin.add(stdin)
+            Pair(0, "<svg/>")
+        }
+
+        D2Runner.renderToSvg("a -> b: hello", "/fake/d2")
+
+        assertEquals(listOf("a -> b: hello"), capturedStdin)
+    }
+
+    @Test
+    fun `renderToSvg passes correct command`() {
+        val capturedCmd = mutableListOf<List<String>>()
+        D2Runner.processRunner = { cmd, _ ->
+            capturedCmd.add(cmd)
+            Pair(0, "<svg/>")
+        }
+
+        D2Runner.renderToSvg("x -> y", "/usr/local/bin/d2")
+
+        assertEquals(listOf(listOf("/usr/local/bin/d2", "-", "-")), capturedCmd)
+    }
+
+    @Test
+    fun `renderToSvg throws on non-zero exit code`() {
+        D2Runner.processRunner = { _, _ -> Pair(1, "parse error at line 3") }
+
+        val ex = assertFailsWith<RuntimeException> {
+            D2Runner.renderToSvg("invalid!!!", "/fake/d2")
+        }
+        assertTrue("Exception should mention exit code", ex.message!!.contains("1"))
+    }
+
+    @Test
+    fun `renderToSvg includes process output in exception message`() {
+        val errorOutput = "D2 compilation error: unexpected token 'invalid'"
+        D2Runner.processRunner = { _, _ -> Pair(1, errorOutput) }
+
+        val ex = assertFailsWith<RuntimeException> {
+            D2Runner.renderToSvg("invalid!!!", "/fake/d2")
+        }
+        assertTrue(ex.message!!.contains(errorOutput))
+    }
+
+    @Test
+    fun `renderToSvg includes d2Arguments in command`() {
+        val capturedCmd = mutableListOf<List<String>>()
+        D2Runner.processRunner = { cmd, _ -> capturedCmd.add(cmd); Pair(0, "<svg/>") }
+
+        D2Runner.renderToSvg("x -> y", "/usr/bin/d2", d2Arguments = "--sketch --theme=200")
+
+        assertEquals(listOf("/usr/bin/d2", "--sketch", "--theme=200", "-", "-"), capturedCmd.first())
+    }
+
+    @Test
+    fun `renderToSvg wraps command with wsl when useWsl is true`() {
+        val capturedCmd = mutableListOf<List<String>>()
+        D2Runner.processRunner = { cmd, _ -> capturedCmd.add(cmd); Pair(0, "<svg/>") }
+
+        D2Runner.renderToSvg("x -> y", "/usr/bin/d2", useWsl = true, wslDistro = "Ubuntu")
+
+        val cmd = capturedCmd.first()
+        assertEquals("wsl.exe", cmd[0])
+        assertContains(cmd, "/usr/bin/d2")
+    }
+
+    @Test
+    fun `renderToSvg truncates very long error output`() {
+        val longOutput = "x".repeat(1000)
+        D2Runner.processRunner = { _, _ -> Pair(1, longOutput) }
+
+        val ex = assertFailsWith<RuntimeException> {
+            D2Runner.renderToSvg("x", "/fake/d2")
+        }
+        // Error message should not exceed ~550 chars (500 cap + boilerplate)
+        assertTrue(ex.message!!.length < 600)
+    }
+}


### PR DESCRIPTION
## Summary

Adds live D2 diagram rendering inside IntelliJ's Markdown preview for fenced `d2` code blocks.

  - Injects a JavaScript extension into the JCEF Markdown preview that detects <code>```d2</code> blocks and sends their source to Kotlin via BrowserPipe
  - Kotlin executes the D2 CLI via stdin→stdout (no temp files), returning SVG rendered by `D2Runner`

## Features:
- IDE theme support: uses `JBColor.isBright()` (the authoritative IntelliJ platform API) to detect the active IDE theme and automatically passes `--theme 200` (Dark Mauve) to the D2 CLI when in dark mode
- Proper D2 fonts: SVG is rendered inside a Shadow DOM to isolate D2's embedded styles from the page. As a consequence, `@font-face` is ignored by JCEF/Chromium inside Shadow DOM — to work around this, fonts are hoisted to the light DOM
- Seamless blending: the SVG canvas background `<rect>` is removed so diagrams blend into the document instead of standing out

## Notes
- Activated only when the Markdown plugin is present (optional dependency via markdown-preview.xml)

## Screenshot

<img width="1747" height="1196" alt="preview" src="https://github.com/user-attachments/assets/65caa573-0f70-4365-8cc6-740a0861f139" />
